### PR TITLE
Add internet speed test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # PROYECTOS-ELE
+
+Este repositorio incluye un script sencillo para medir la velocidad de tu conexión a internet.
+
+## Requisitos
+
+- Python 3
+- speedtest-cli (`pip install speedtest-cli`)
+
+## Uso
+
+```bash
+python velocidad_internet.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+speedtest-cli

--- a/velocidad_internet.py
+++ b/velocidad_internet.py
@@ -1,0 +1,14 @@
+import speedtest
+
+
+def medir_velocidad():
+    st = speedtest.Speedtest(secure=True)
+    st.get_best_server()
+    descarga = st.download() / 1_000_000
+    carga = st.upload() / 1_000_000
+    print(f"Velocidad de descarga: {descarga:.2f} Mbps")
+    print(f"Velocidad de carga: {carga:.2f} Mbps")
+
+
+if __name__ == "__main__":
+    medir_velocidad()


### PR DESCRIPTION
## Summary
- Add script to measure internet speed using speedtest-cli
- Document usage and requirements

## Testing
- `python velocidad_internet.py` (fails: ConfigRetrievalError 403)


------
https://chatgpt.com/codex/tasks/task_e_6893048681e88321a6a0b70fda48b292